### PR TITLE
improving GeneralClientMessages for socket.io listener

### DIFF
--- a/typedSocket.d.ts
+++ b/typedSocket.d.ts
@@ -29,7 +29,9 @@ export namespace internal {
      * messages that the server can receive from any client
      */
     export interface GeneralClientMessages {
-        disconnect: void;
+        disconnect: string;
+        disconnecting: string;
+        error: any;
     }
 
     interface ClientSideSocketI<


### PR DESCRIPTION
This adds `error`, `disconnecting` and `disconnect` to `ServerSideClientSocketI` listeners